### PR TITLE
Use blackfriday-confluence for confluence wiki output.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -5,7 +5,7 @@
   branch = "master"
   name = "github.com/atotto/clipboard"
   packages = ["."]
-  revision = "bb272b845f1112e10117e3e45ce39f690c0001ad"
+  revision = "5e2c7bddca04488284428a201e4a15615f7a5074"
 
 [[projects]]
   name = "github.com/inconshreveable/mousetrap"
@@ -15,15 +15,21 @@
 
 [[projects]]
   branch = "master"
-  name = "github.com/kentaro-m/blackfriday"
+  name = "github.com/kentaro-m/blackfriday-confluence"
   packages = ["."]
-  revision = "621bacd540c11fc546edfc013d89cbe94233f9be"
+  revision = "816d28cddf0b44b29c6bb3a35e5e389419f6bdce"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/shurcooL/sanitized_anchor_name"
+  packages = ["."]
+  revision = "86672fcb3f950f35f2e675df2240550f2a50762f"
 
 [[projects]]
   branch = "master"
   name = "github.com/spf13/cobra"
   packages = ["."]
-  revision = "b78744579491c1ceeaaa3b40205e56b0591b93a3"
+  revision = "4dab30cb33e6633c33c787106bafbfbfdde7842d"
 
 [[projects]]
   name = "github.com/spf13/pflag"
@@ -31,9 +37,15 @@
   revision = "e57e3eeb33f795204c1ca35f56c44f83227c6e66"
   version = "v1.0.0"
 
+[[projects]]
+  name = "gopkg.in/russross/blackfriday.v2"
+  packages = ["."]
+  revision = "cadec560ec52d93835bf2f15bd794700d3a2473b"
+  version = "v2.0.0"
+
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "c2becd2a102695ec10e53a9443a13546f42f28836fd5eb036548b79adae6c4a7"
+  inputs-digest = "25b297b87b5c8700fa197db73fb26427d3ad7a6cdb7bf881b59799d40ba0f71d"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -27,8 +27,4 @@
 
 [[constraint]]
   branch = "master"
-  name = "github.com/kentaro-m/blackfriday"
-
-[[constraint]]
-  branch = "master"
   name = "github.com/spf13/cobra"

--- a/confluence/confluence.go
+++ b/confluence/confluence.go
@@ -3,25 +3,21 @@ package confluence
 import (
 	"fmt"
 
-	"github.com/kentaro-m/blackfriday"
+	bfconfluence "github.com/kentaro-m/blackfriday-confluence"
 )
 
+// Confluence is a type that implements the interface for confluence wiki output.
 type Confluence struct {
 	Contents string
 }
 
+// Convert renders confluence wiki text from markdown text.
 func (c *Confluence) Convert(input []byte) {
-	renderer := blackfriday.ConfluenceRenderer(0)
-	extensions := 0
-	extensions |= blackfriday.EXTENSION_FENCED_CODE
-	extensions |= blackfriday.EXTENSION_TABLES
-	extensions |= blackfriday.EXTENSION_STRIKETHROUGH
-	extensions |= blackfriday.EXTENSION_NO_EMPTY_LINE_BEFORE_BLOCK
-
-	output := blackfriday.Markdown(input, renderer, extensions)
+	output := bfconfluence.Run(input)
 	c.Contents = string(output)
 }
 
+// Preview displays confluence wiki document.
 func (c *Confluence) Preview() {
 	fmt.Println(c.Contents)
 }


### PR DESCRIPTION
Use blackfriday-confluence for confluence wiki output.